### PR TITLE
Fixing Tool Calling

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "prepare": "husky",
     "lint": "pnpm --filter ollama-ai-provider run lint",
     "type-check": "pnpm --filter ollama-ai-provider run type-check",
-    "prettier-check": "pnpm --filter ollama-ai-provider run prettier",
+    "prettier-check": "pnpm --filter ollama-ai-provider run prettier-check",
     "test": "pnpm --filter ollama-ai-provider run test",
     "ci:release": "pnpm clean && pnpm build && changeset publish",
     "ci:version": "changeset version && pnpm install --no-frozen-lockfile"

--- a/packages/ollama/package.json
+++ b/packages/ollama/package.json
@@ -26,8 +26,8 @@
   "author": "Sergio Gómez Bachiller <decano@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ai-sdk/provider": "0.0.11",
-    "@ai-sdk/provider-utils": "1.0.0",
+    "@ai-sdk/provider": "0.0.14",
+    "@ai-sdk/provider-utils": "1.0.5",
     "partial-json": "^0.1.7"
   },
   "devDependencies": {

--- a/packages/ollama/src/convert-to-ollama-chat-messages.test.ts
+++ b/packages/ollama/src/convert-to-ollama-chat-messages.test.ts
@@ -26,6 +26,46 @@ describe('convertToOllamaChatMessages', () => {
         content: [{ text: 'Assistant text message', type: 'text' }],
         role: 'assistant',
       },
+      {
+        content: [
+          { text: "What's the weather like today in Paris?", type: 'text' },
+        ],
+        role: 'user',
+      },
+      {
+        content: [
+          {
+            args: {
+              format: 'celsius',
+              location: 'Paris, France',
+            },
+            toolCallId: '89a1e453-0bce-4de3-a456-c54bed09c520',
+            toolName: 'get_current_weather',
+            type: 'tool-call',
+          },
+        ],
+        role: 'assistant',
+      },
+      {
+        content: [
+          {
+            result: '22',
+            toolCallId: '89a1e453-0bce-4de3-a456-c54bed09c520',
+            toolName: 'get_current_weather',
+            type: 'tool-result',
+          },
+        ],
+        role: 'tool',
+      },
+      {
+        content: [
+          {
+            text: 'The current temperature in Paris, France is 22 degrees Celsius.',
+            type: 'text',
+          },
+        ],
+        role: 'assistant',
+      },
     ]
 
     // Act
@@ -43,6 +83,25 @@ describe('convertToOllamaChatMessages', () => {
         role: 'user',
       },
       { content: 'Assistant text message', role: 'assistant' },
+      // Tool related messages based on: https://github.com/ollama/ollama/blob/f5e3939220e9cd3d7a636708bc9df031ebfd4854/server/testdata/tools/messages.json
+      {
+        content: "What's the weather like today in Paris?",
+        role: 'user',
+      },
+      {
+        content: '',
+        role: 'assistant',
+      },
+      {
+        content: '22',
+        role: 'tool',
+        tool_call_id: '89a1e453-0bce-4de3-a456-c54bed09c520',
+      },
+      {
+        content:
+          'The current temperature in Paris, France is 22 degrees Celsius.',
+        role: 'assistant',
+      },
     ]
     expect(result).toEqual(expectedResult)
   })

--- a/packages/ollama/src/convert-to-ollama-chat-messages.ts
+++ b/packages/ollama/src/convert-to-ollama-chat-messages.ts
@@ -6,7 +6,7 @@ import {
 import { convertUint8ArrayToBase64 } from '@ai-sdk/provider-utils'
 
 import { injectToolsSchemaIntoSystem } from '@/generate-tool/inject-tools-schema-into-system'
-import { OllamaChatPrompt } from '@/ollama-chat-prompt'
+import { OllamaChatPrompt, OllamaToolMessage } from '@/ollama-chat-prompt'
 
 export function convertToOllamaChatMessages(
   prompt: LanguageModelV1Prompt,
@@ -75,6 +75,20 @@ export function convertToOllamaChatMessages(
             .join(''),
           role: 'assistant',
         })
+        break
+      }
+
+      case 'tool': {
+        messages.push(
+          ...content.map(
+            (part) =>
+              ({
+                content: part.result,
+                role: 'tool',
+                tool_call_id: part.toolCallId,
+              }) as OllamaToolMessage,
+          ),
+        )
         break
       }
 

--- a/packages/ollama/src/generate-tool/infer-tool-calls-from-assistant-message.test.ts
+++ b/packages/ollama/src/generate-tool/infer-tool-calls-from-assistant-message.test.ts
@@ -24,7 +24,7 @@ describe('inferToolCallsFromAssistantMessage', () => {
     expect(parsedResponse.message.tool_calls).toContainEqual(
       expect.objectContaining({
         function: {
-          arguments: JSON.stringify({ numbers: [2, 3] }),
+          arguments: { numbers: [2, 3] },
           name: 'sum',
         },
         id: expect.any(String),
@@ -54,7 +54,7 @@ describe('inferToolCallsFromAssistantMessage', () => {
     expect(parsedResponse.message.tool_calls).toContainEqual(
       expect.objectContaining({
         function: {
-          arguments: JSON.stringify({ numbers: [2, 3] }),
+          arguments: { numbers: [2, 3] },
           name: 'sum',
         },
         id: expect.any(String),

--- a/packages/ollama/src/generate-tool/infer-tool-calls-from-response.ts
+++ b/packages/ollama/src/generate-tool/infer-tool-calls-from-response.ts
@@ -22,7 +22,7 @@ export function inferToolCallsFromResponse(
         role: 'assistant',
         tool_calls: parsedTools.map((parsedTool) => ({
           function: {
-            arguments: JSON.stringify(parsedTool.arguments),
+            arguments: parsedTool.arguments,
             name: parsedTool.name,
           },
           id: generateId(),

--- a/packages/ollama/src/generate-tool/infer-tool-calls-from-stream.test.ts
+++ b/packages/ollama/src/generate-tool/infer-tool-calls-from-stream.test.ts
@@ -22,48 +22,47 @@ describe('InferToolCallsFromStream', () => {
     vi.resetAllMocks()
   })
 
-  describe.each<CallModeType[]>([
-    ['object-json'],
-    ['object-grammar'],
-    ['regular'],
-  ])('should ignore no tooling %s mode types', (type) => {
-    it('should return is not a call stream', () => {
-      // Arrange
-      const inferToolCallsFromStream = new InferToolCallsFromStream({
-        type,
-      })
-      const delta = 'Hi!'
+  describe.each<CallModeType[]>([['object-json'], ['regular']])(
+    'should ignore no tooling %s mode types',
+    (type) => {
+      it('should return is not a call stream', () => {
+        // Arrange
+        const inferToolCallsFromStream = new InferToolCallsFromStream({
+          type,
+        })
+        const delta = 'Hi!'
 
-      // Act
-      const isToolCallStream = inferToolCallsFromStream.parse({
-        controller,
-        delta,
-      })
+        // Act
+        const isToolCallStream = inferToolCallsFromStream.parse({
+          controller,
+          delta,
+        })
 
-      // Assert
-      expect(isToolCallStream).toBeFalsy()
-      expect(inferToolCallsFromStream.detectedToolCall).toBeFalsy()
-      expect(controller.enqueue).not.toBeCalled()
-    })
-
-    it('should return stop finish reason', () => {
-      // Arrange
-      const inferToolCallsFromStream = new InferToolCallsFromStream({
-        type,
-      })
-      const delta = 'Hi!'
-
-      // Act
-      inferToolCallsFromStream.parse({
-        controller,
-        delta,
+        // Assert
+        expect(isToolCallStream).toBeFalsy()
+        expect(inferToolCallsFromStream.detectedToolCall).toBeFalsy()
+        expect(controller.enqueue).not.toBeCalled()
       })
 
-      // Assert
-      expect(inferToolCallsFromStream.finish({ controller })).toEqual('stop')
-      expect(controller.enqueue).not.toBeCalled()
-    })
-  })
+      it('should return stop finish reason', () => {
+        // Arrange
+        const inferToolCallsFromStream = new InferToolCallsFromStream({
+          type,
+        })
+        const delta = 'Hi!'
+
+        // Act
+        inferToolCallsFromStream.parse({
+          controller,
+          delta,
+        })
+
+        // Assert
+        expect(inferToolCallsFromStream.finish({ controller })).toEqual('stop')
+        expect(controller.enqueue).not.toBeCalled()
+      })
+    },
+  )
 
   describe('should parse object-tool mode calls', () => {
     it('should detect is a tool call stream', () => {

--- a/packages/ollama/src/ollama-chat-language-model.test.ts
+++ b/packages/ollama/src/ollama-chat-language-model.test.ts
@@ -90,6 +90,7 @@ describe('goGenerate', () => {
     })
 
     expect(rawResponse?.headers).toStrictEqual({
+      'content-length': '269',
       // default headers:
       'content-type': 'application/json',
 

--- a/packages/ollama/src/ollama-chat-language-model.ts
+++ b/packages/ollama/src/ollama-chat-language-model.ts
@@ -4,7 +4,6 @@ import {
   LanguageModelV1CallWarning,
   LanguageModelV1FinishReason,
   LanguageModelV1StreamPart,
-  UnsupportedFunctionalityError,
 } from '@ai-sdk/provider'
 import {
   createJsonResponseHandler,
@@ -140,12 +139,6 @@ export class OllamaChatLanguageModel implements LanguageModelV1 {
           type,
           warnings,
         }
-      }
-
-      case 'object-grammar': {
-        throw new UnsupportedFunctionalityError({
-          functionality: 'object-grammar mode',
-        })
       }
 
       default: {

--- a/packages/ollama/src/ollama-chat-language-model.ts
+++ b/packages/ollama/src/ollama-chat-language-model.ts
@@ -84,7 +84,7 @@ export class OllamaChatLanguageModel implements LanguageModelV1 {
         return {
           args: {
             ...baseArguments,
-            messages: convertToOllamaChatMessages(prompt, tools),
+            messages: convertToOllamaChatMessages(prompt),
             tools: tools?.map((tool) => ({
               function: {
                 description: tool.description,
@@ -116,11 +116,7 @@ export class OllamaChatLanguageModel implements LanguageModelV1 {
           args: {
             ...baseArguments,
             format: 'json',
-            messages: convertToOllamaChatMessages(
-              prompt,
-              [mode.tool],
-              mode.tool.name,
-            ),
+            messages: convertToOllamaChatMessages(prompt),
             tool_choice: {
               function: { name: mode.tool.name },
               type: 'function',

--- a/packages/ollama/src/ollama-chat-language-model.ts
+++ b/packages/ollama/src/ollama-chat-language-model.ts
@@ -177,7 +177,7 @@ export class OllamaChatLanguageModel implements LanguageModelV1 {
       rawResponse: { headers: responseHeaders },
       text: response.message.content ?? undefined,
       toolCalls: response.message.tool_calls?.map((toolCall) => ({
-        args: toolCall.function.arguments,
+        args: JSON.stringify(toolCall.function.arguments),
         toolCallId: generateId(),
         toolCallType: 'function',
         toolName: toolCall.function.name,
@@ -287,7 +287,7 @@ const ollamaChatResponseSchema = z.object({
       .array(
         z.object({
           function: z.object({
-            arguments: z.string(),
+            arguments: z.record(z.any()),
             name: z.string(),
           }),
         }),

--- a/packages/ollama/src/ollama-chat-prompt.ts
+++ b/packages/ollama/src/ollama-chat-prompt.ts
@@ -26,7 +26,7 @@ export interface OllamaAssistantMessage {
 }
 
 export interface OllamaToolMessage {
-  content: unknown
+  content: string
   role: 'tool'
   tool_call_id: string
 }

--- a/packages/ollama/src/ollama-chat-prompt.ts
+++ b/packages/ollama/src/ollama-chat-prompt.ts
@@ -4,6 +4,7 @@ export type OllamaChatMessage =
   | OllamaSystemMessage
   | OllamaUserMessage
   | OllamaAssistantMessage
+  | OllamaToolMessage
 
 export interface OllamaSystemMessage {
   content: string
@@ -22,6 +23,12 @@ export interface OllamaAssistantMessage {
   images?: Array<string>
   role: 'assistant'
   tool_calls?: Array<MessageToolCall>
+}
+
+export interface OllamaToolMessage {
+  content: unknown
+  role: 'tool'
+  tool_call_id: string
 }
 
 export interface MessageToolCall {

--- a/packages/ollama/src/ollama-embedding-model.test.ts
+++ b/packages/ollama/src/ollama-embedding-model.test.ts
@@ -42,6 +42,7 @@ describe('doEmbed', () => {
     const { rawResponse } = await model.doEmbed({ values: testValues })
 
     expect(rawResponse?.headers).toStrictEqual({
+      'content-length': '35',
       // default headers:
       'content-type': 'application/json',
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,11 +100,11 @@ importers:
   packages/ollama:
     dependencies:
       '@ai-sdk/provider':
-        specifier: 0.0.11
-        version: 0.0.11
+        specifier: 0.0.14
+        version: 0.0.14
       '@ai-sdk/provider-utils':
-        specifier: 1.0.0
-        version: 1.0.0(zod@3.22.4)
+        specifier: 1.0.5
+        version: 1.0.5(zod@3.22.4)
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
@@ -136,8 +136,21 @@ packages:
       zod:
         optional: true
 
+  '@ai-sdk/provider-utils@1.0.5':
+    resolution: {integrity: sha512-XfOawxk95X3S43arn2iQIFyWGMi0DTxsf9ETc6t7bh91RPWOOPYN1tsmS5MTKD33OGJeaDQ/gnVRzXUCRBrckQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@ai-sdk/provider@0.0.11':
     resolution: {integrity: sha512-VTipPQ92Moa5Ovg/nZIc8yNoIFfukZjUHZcQMduJbiUh3CLQyrBAKTEV9AwjPy8wgVxj3+GZjon0yyOJKhfp5g==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@0.0.14':
+    resolution: {integrity: sha512-gaQ5Y033nro9iX1YUjEDFDRhmMcEiCk56LJdIUbX5ozEiCNCfpiBpEqrjSp/Gp5RzBS2W0BVxfG7UGW6Ezcrzg==}
     engines: {node: '>=18'}
 
   '@ai-sdk/react@0.0.15':
@@ -3143,7 +3156,20 @@ snapshots:
     optionalDependencies:
       zod: 3.22.4
 
+  '@ai-sdk/provider-utils@1.0.5(zod@3.22.4)':
+    dependencies:
+      '@ai-sdk/provider': 0.0.14
+      eventsource-parser: 1.1.2
+      nanoid: 3.3.6
+      secure-json-parse: 2.7.0
+    optionalDependencies:
+      zod: 3.22.4
+
   '@ai-sdk/provider@0.0.11':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@0.0.14':
     dependencies:
       json-schema: 0.4.0
 


### PR DESCRIPTION
Existing implementation expects function call arguments as strings (instead of objects) and the roundtrip for feeding back the result requires an updated message structure. 

Also updated the @ai/provider dependencies and adjusted the tests to make everything is up-to-date.

Tested with mistral and was able to get it working well