### PR TITLE
fix: handle reasoning type

### DIFF
--- a/packages/ollama/package-lock.json
+++ b/packages/ollama/package-lock.json
@@ -1,0 +1,326 @@
+{
+  "name": "ollama-ai-provider",
+  "version": "1.2.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ollama-ai-provider",
+      "version": "1.2.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "^1.1.3",
+        "@ai-sdk/provider-utils": "^2.0.0",
+        "partial-json": "0.1.7"
+      },
+      "devDependencies": {
+        "@edge-runtime/vm": "^3.2.0",
+        "@types/node": "^18.19.56",
+        "tsup": "^8.3.0",
+        "typescript": "5.6.3",
+        "zod": "3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/@ai-sdk+provider-utils@2.0.2_zod@3.23.8/node_modules/@ai-sdk/provider-utils": {
+      "version": "2.0.2",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "1.0.1",
+        "eventsource-parser": "^3.0.0",
+        "nanoid": "^3.3.7",
+        "secure-json-parse": "^2.7.0"
+      },
+      "devDependencies": {
+        "@types/node": "^18",
+        "@vercel/ai-tsconfig": "0.0.0",
+        "msw": "2.6.4",
+        "tsup": "^8",
+        "typescript": "5.6.3",
+        "zod": "3.23.8"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/@edge-runtime+vm@3.2.0/node_modules/@edge-runtime/vm": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@edge-runtime/primitives": "4.1.0"
+      },
+      "devDependencies": {
+        "@types/test-listen": "1.1.2",
+        "@types/ws": "8.5.10",
+        "test-listen": "1.1.0",
+        "ws": "8.16.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "../../node_modules/.pnpm/@types+node@18.19.56/node_modules/@types/node": {
+      "version": "18.19.56",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "../../node_modules/.pnpm/partial-json@0.1.7/node_modules/partial-json": {
+      "version": "0.1.7",
+      "license": "MIT",
+      "devDependencies": {
+        "@vitest/coverage-istanbul": "^1.2.2",
+        "@vitest/ui": "^1.2.2",
+        "typescript": "^5.3.3",
+        "vitest": "^1.2.2"
+      }
+    },
+    "../../node_modules/.pnpm/tsup@8.3.0_jiti@1.21.6_postcss@8.4.49_typescript@5.6.3_yaml@2.6.1/node_modules/tsup": {
+      "version": "8.3.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.0.0",
+        "cac": "^6.7.14",
+        "chokidar": "^3.6.0",
+        "consola": "^3.2.3",
+        "debug": "^4.3.5",
+        "esbuild": "^0.23.0",
+        "execa": "^5.1.1",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.0.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.19.0",
+        "source-map": "0.8.0-beta.0",
+        "sucrase": "^3.35.0",
+        "tinyglobby": "^0.2.1",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "devDependencies": {
+        "@microsoft/api-extractor": "^7.47.2",
+        "@rollup/plugin-json": "6.1.0",
+        "@swc/core": "1.7.0",
+        "@types/debug": "4.1.12",
+        "@types/fs-extra": "11.0.4",
+        "@types/node": "20.14.11",
+        "@types/resolve": "1.20.6",
+        "flat": "6.0.1",
+        "fs-extra": "11.2.0",
+        "postcss": "8.4.39",
+        "postcss-simple-vars": "7.0.1",
+        "prettier": "3.3.3",
+        "resolve": "1.22.8",
+        "rollup-plugin-dts": "6.1.1",
+        "sass": "1.77.8",
+        "strip-json-comments": "5.0.1",
+        "svelte": "3.49.0",
+        "svelte-preprocess": "5.0.3",
+        "terser": "^5.31.3",
+        "ts-essentials": "10.0.1",
+        "tsup": "8.2.1",
+        "typescript": "5.5.3",
+        "vitest": "2.0.3",
+        "wait-for-expect": "3.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "../../node_modules/.pnpm/typescript@5.6.3/node_modules/typescript": {
+      "version": "5.6.3",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "devDependencies": {
+        "@dprint/formatter": "^0.4.1",
+        "@dprint/typescript": "0.91.6",
+        "@esfx/canceltoken": "^1.0.0",
+        "@eslint/js": "^9.9.0",
+        "@octokit/rest": "^21.0.1",
+        "@types/chai": "^4.3.17",
+        "@types/diff": "^5.2.1",
+        "@types/minimist": "^1.2.5",
+        "@types/mocha": "^10.0.7",
+        "@types/ms": "^0.7.34",
+        "@types/node": "latest",
+        "@types/source-map-support": "^0.5.10",
+        "@types/which": "^3.0.4",
+        "@typescript-eslint/rule-tester": "^8.1.0",
+        "@typescript-eslint/type-utils": "^8.1.0",
+        "@typescript-eslint/utils": "^8.1.0",
+        "azure-devops-node-api": "^14.0.2",
+        "c8": "^10.1.2",
+        "chai": "^4.5.0",
+        "chalk": "^4.1.2",
+        "chokidar": "^3.6.0",
+        "diff": "^5.2.0",
+        "dprint": "^0.47.2",
+        "esbuild": "^0.23.0",
+        "eslint": "^9.9.0",
+        "eslint-formatter-autolinkable-stylish": "^1.4.0",
+        "eslint-plugin-regexp": "^2.6.0",
+        "fast-xml-parser": "^4.4.1",
+        "glob": "^10.4.5",
+        "globals": "^15.9.0",
+        "hereby": "^1.9.0",
+        "jsonc-parser": "^3.3.1",
+        "knip": "^5.27.2",
+        "minimist": "^1.2.8",
+        "mocha": "^10.7.3",
+        "mocha-fivemat-progress-reporter": "^0.1.0",
+        "monocart-coverage-reports": "^2.10.2",
+        "ms": "^2.1.3",
+        "node-fetch": "^3.3.2",
+        "playwright": "^1.46.0",
+        "source-map-support": "^0.5.21",
+        "tslib": "^2.6.3",
+        "typescript": "^5.5.4",
+        "typescript-eslint": "^8.1.0",
+        "which": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "../../node_modules/.pnpm/zod@3.23.8/node_modules/zod": {
+      "version": "3.23.8",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@babel/core": "^7.22.5",
+        "@babel/preset-env": "^7.22.5",
+        "@babel/preset-typescript": "^7.22.5",
+        "@jest/globals": "^29.4.3",
+        "@rollup/plugin-typescript": "^8.2.0",
+        "@swc/core": "^1.3.66",
+        "@swc/jest": "^0.2.26",
+        "@types/benchmark": "^2.1.0",
+        "@types/jest": "^29.2.2",
+        "@types/node": "14",
+        "@typescript-eslint/eslint-plugin": "^5.15.0",
+        "@typescript-eslint/parser": "^5.15.0",
+        "babel-jest": "^29.5.0",
+        "benchmark": "^2.1.4",
+        "dependency-cruiser": "^9.19.0",
+        "eslint": "^8.11.0",
+        "eslint-config-prettier": "^8.5.0",
+        "eslint-plugin-ban": "^1.6.0",
+        "eslint-plugin-import": "^2.25.4",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
+        "eslint-plugin-unused-imports": "^2.0.0",
+        "husky": "^7.0.4",
+        "jest": "^29.3.1",
+        "lint-staged": "^12.3.7",
+        "nodemon": "^2.0.15",
+        "prettier": "^2.6.0",
+        "pretty-quick": "^3.1.3",
+        "rollup": "^2.70.1",
+        "ts-jest": "^29.1.0",
+        "ts-morph": "^14.0.0",
+        "ts-node": "^10.9.1",
+        "tslib": "^2.3.1",
+        "tsx": "^3.8.0",
+        "typescript": "~4.5.5",
+        "vitest": "^0.32.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-1.1.3.tgz",
+      "integrity": "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "resolved": "../../node_modules/.pnpm/@ai-sdk+provider-utils@2.0.2_zod@3.23.8/node_modules/@ai-sdk/provider-utils",
+      "link": true
+    },
+    "node_modules/@edge-runtime/vm": {
+      "resolved": "../../node_modules/.pnpm/@edge-runtime+vm@3.2.0/node_modules/@edge-runtime/vm",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "resolved": "../../node_modules/.pnpm/@types+node@18.19.56/node_modules/@types/node",
+      "link": true
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
+    },
+    "node_modules/partial-json": {
+      "resolved": "../../node_modules/.pnpm/partial-json@0.1.7/node_modules/partial-json",
+      "link": true
+    },
+    "node_modules/tsup": {
+      "resolved": "../../node_modules/.pnpm/tsup@8.3.0_jiti@1.21.6_postcss@8.4.49_typescript@5.6.3_yaml@2.6.1/node_modules/tsup",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "resolved": "../../node_modules/.pnpm/typescript@5.6.3/node_modules/typescript",
+      "link": true
+    },
+    "node_modules/zod": {
+      "resolved": "../../node_modules/.pnpm/zod@3.23.8/node_modules/zod",
+      "link": true
+    }
+  }
+}

--- a/packages/ollama/package.json
+++ b/packages/ollama/package.json
@@ -26,7 +26,7 @@
   "author": "Sergio Gómez Bachiller <decano@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ai-sdk/provider": "^1.0.0",
+    "@ai-sdk/provider": "^1.1.3",
     "@ai-sdk/provider-utils": "^2.0.0",
     "partial-json": "0.1.7"
   },

--- a/packages/ollama/src/convert-to-ollama-chat-messages.test.ts
+++ b/packages/ollama/src/convert-to-ollama-chat-messages.test.ts
@@ -23,12 +23,17 @@ describe('assistant messages', () => {
   it('should convert messages with only a text part to a string content', async () => {
     const result = convertToOllamaChatMessages([
       {
-        content: [{ text: 'Hello', type: 'text' }],
+        content: [
+          { text: 'Hello', type: 'text' },
+          { text: '<think>thinking</think>', type: 'reasoning' },
+        ],
         role: 'assistant',
       },
     ])
 
-    expect(result).toEqual([{ content: 'Hello', role: 'assistant' }])
+    expect(result).toEqual([
+      { content: 'Hello,<think>thinking</think>', role: 'assistant' },
+    ])
   })
 })
 

--- a/packages/ollama/src/convert-to-ollama-chat-messages.ts
+++ b/packages/ollama/src/convert-to-ollama-chat-messages.ts
@@ -74,9 +74,21 @@ export function convertToOllamaChatMessages(
               })
               break
             }
+            case 'file': {
+              throw new UnsupportedFunctionalityError({
+                functionality: 'File parts in assistant messages',
+              })
+            }
+            case 'redacted-reasoning': {
+              throw new UnsupportedFunctionalityError({
+                functionality: 'Redacted reasoning parts in assistant messages',
+              })
+            }
             default: {
               const _exhaustiveCheck: never = part
-              throw new Error(`Unsupported part: ${_exhaustiveCheck}`)
+              throw new Error(
+                `Unsupported part: ${JSON.stringify(_exhaustiveCheck)}`,
+              )
             }
           }
         }

--- a/packages/ollama/src/convert-to-ollama-chat-messages.ts
+++ b/packages/ollama/src/convert-to-ollama-chat-messages.ts
@@ -58,6 +58,7 @@ export function convertToOllamaChatMessages(
 
         for (const part of content) {
           switch (part.type) {
+            case 'reasoning':
             case 'text': {
               text.push(part.text)
               break

--- a/packages/ollama/src/ollama-error.ts
+++ b/packages/ollama/src/ollama-error.ts
@@ -12,7 +12,9 @@ const ollamaErrorDataSchema = z.object({
 
 export type OllamaErrorData = z.infer<typeof ollamaErrorDataSchema>
 
-export const ollamaFailedResponseHandler = createJsonErrorResponseHandler({
+export const ollamaFailedResponseHandler: ReturnType<
+  typeof createJsonErrorResponseHandler
+> = createJsonErrorResponseHandler({
   errorSchema: ollamaErrorDataSchema,
   errorToMessage: (data) => data.error.message,
 })


### PR DESCRIPTION
This proposal fixes an issue when using `extractReasoningMiddleware` which splits response.message into parts "text" and "reasoning", which was previously unsupported and throws errors

See Issue: https://github.com/sgomez/ollama-ai-provider/issues/44